### PR TITLE
Protocol agnostic Vavr property links 

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
                 </div>
                 <div class="col-lg-3 col-md-6 text-center">
                     <div class="feature-box-primary">
-                        <a target="_blank" href="//docs.vavr.io">
+                        <a target="_blank" href="http://docs.vavr.io">
                             <i class="fa fa-4x fa-book"></i>
                             <h3>Documentation</h3>
                             <p class="text-faded">The documentation gives an overview and covers the concepts in depth. It is the best way to get started with Vavr.</p>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
                     </li>
                     -->
                     <li>
-                        <a class="page-scroll" href="http://blog.vavr.io">Blog</a>
+                        <a class="page-scroll" href="//blog.vavr.io">Blog</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="#downloads">Downloads</a>
@@ -255,7 +255,7 @@
                 </div>
                 <div class="col-lg-3 col-md-6 text-center">
                     <div class="feature-box-primary">
-                        <a target="_blank" href="http://docs.vavr.io">
+                        <a target="_blank" href="//docs.vavr.io">
                             <i class="fa fa-4x fa-book"></i>
                             <h3>Documentation</h3>
                             <p class="text-faded">The documentation gives an overview and covers the concepts in depth. It is the best way to get started with Vavr.</p>
@@ -361,7 +361,7 @@
         <div class="container text-center">
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <h2>Please visit our <a target="_blank" href="http://blog.vavr.io"><strong>Blog</strong></a> or find us here:</h2>
+                    <h2>Please visit our <a target="_blank" href="//blog.vavr.io"><strong>Blog</strong></a> or find us here:</h2>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The updated vavr property links will now leverage the protocol used to deliver the markup.

Should resolve issue #8 .