### PR TITLE
Fixed typo on home page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
                             <div class="carousel-caption">
                                 <h2>🎉⭐️ VAVR TURNS <strong>5</strong> YO ☘️🍄</h2>
                                 <p style="font-size: 1.5em">
-                                    The first version, called <em>Javaslang</em>, was released on 19h march 2014.
+                                    The first version, called <em>Javaslang</em>, was released on 19 March 2014.
                                     A big <strong>thank you</strong> to all of our users, committers and sponsors for supporting VAVR! 👍🏼
                                 </p>
                             </div>


### PR DESCRIPTION
The original release date of Javaslang had a typo and an unusual formatting.

Proposes to fix https://github.com/vavr-io/vavr-io.github.io/issues/12.